### PR TITLE
Add Vault service

### DIFF
--- a/cluster/apps/kustomization.yaml
+++ b/cluster/apps/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - influxdb
   - code-server
   - kube-dashboard
+  - vault

--- a/cluster/apps/vault/helm-release.yaml
+++ b/cluster/apps/vault/helm-release.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: vault
+  namespace: apps
+spec:
+  interval: 5m
+  chart:
+    spec:
+      # renovate: registryUrl=https://helm.releases.hashicorp.com
+      chart: vault
+      version: 0.19.0
+      sourceRef:
+        kind: HelmRepository
+        name: hashicorp-charts
+        namespace: flux-system
+      interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+  values:
+    global:
+      # enabled is the master enabled switch. Setting this to true or false
+      # will enable or disable all the components within this chart by default.
+      enabled: true
+    server:
+      enabled: true
+      image:
+        repository: "hashicorp/vault"
+        tag: "1.11.2"
+        # Overrides the default Image Pull Policy
+        pullPolicy: IfNotPresent
+      updateStrategyType: "OnDelete"
+      # Supported log levels include: trace, debug, info, warn, error
+      logLevel: "info"
+      # Supported log formats include: standard, json
+      logFormat: "json"
+      ingress:
+        enabled: true
+        ingressClassName: traefik
+        pathType: Prefix
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-production
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        hosts:
+          - host: vault.${SECRET_DOMAIN}
+            paths:
+              - /
+              - /vault
+        tls: 
+          - hosts:
+              - vault.${SECRET_DOMAIN}
+            secretName: vault-tls
+      readinessProbe:
+        enabled: true
+        failureThreshold: 2
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        successThreshold: 1
+        timeoutSeconds: 3
+      livenessProbe:
+        enabled: false
+        path: "/v1/sys/health?standbyok=true"
+        failureThreshold: 2
+        initialDelaySeconds: 60
+        periodSeconds: 5
+        successThreshold: 1
+        timeoutSeconds: 3
+      # Enables a headless service to be used by the Vault Statefulset
+      service:
+        enabled: true
+        # clusterIP controls whether a Cluster IP address is attached to the
+        # Vault service within Kubernetes.  By default the Vault service will
+        # be given a Cluster IP address, set to None to disable.  When disabled
+        # Kubernetes will create a "headless" service.  Headless services can be
+        # used to communicate with pods directly through DNS instead of a round robin
+        # load balancer.
+        # clusterIP: None
+
+        # Configures the service type for the main Vault service.  Can be ClusterIP
+        # or NodePort.
+        #type: ClusterIP
+
+        # The externalTrafficPolicy can be set to either Cluster or Local
+        # and is only valid for LoadBalancer and NodePort service types.
+        # The default value is Cluster.
+        # ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-traffic-policy
+        externalTrafficPolicy: Cluster
+
+        # If type is set to "NodePort", a specific nodePort value can be configured,
+        # will be random if left blank.
+        #nodePort: 30000
+
+        # Port on which Vault server is listening
+        port: 8200
+        # Target port to which the service should be mapped to
+        targetPort: 8200
+        # Extra annotations for the service definition. This can either be YAML or a
+        # YAML-formatted multi-line templated string map of the annotations to apply
+        # to the service.
+        annotations: {}
+      # This configures the Vault Statefulset to create a PVC for data
+      # storage when using the file or raft backend storage engines.
+      # See https://www.vaultproject.io/docs/configuration/storage/index.html to know more
+      dataStorage:
+        enabled: true
+        size: 5Gi
+        mountPath: "/vault/data"
+        # Name of the storage class to use.  If null it will use the
+        # configured default Storage Class.
+        storageClass: null
+        accessMode: ReadWriteOnce
+      # This configures the Vault Statefulset to create a PVC for audit
+      # logs.  Once Vault is deployed, initialized and unsealed, Vault must
+      # be configured to use this for audit logs.  This will be mounted to
+      # /vault/audit
+      # See https://www.vaultproject.io/docs/audit/index.html to know more
+      auditStorage:
+        enabled: false
+        # Size of the PVC created
+        size: 5Gi
+        # Location where the PVC will be mounted.
+        mountPath: "/vault/audit"
+        # Name of the storage class to use.  If null it will use the
+        # configured default Storage Class.
+        storageClass: null
+        # Access Mode of the storage device being used for the PVC
+        accessMode: ReadWriteOnce
+        # Annotations to apply to the PVC
+        annotations: {}
+      # Run Vault in "standalone" mode. This is the default mode that will deploy if
+      # no arguments are given to helm. This requires a PVC for data storage to use
+      # the "file" backend.  This mode is not highly available and should not be scaled
+      # past a single replica.
+      standalone:
+        enabled: "-"
+
+        # config is a raw string of default configuration when using a Stateful
+        # deployment. Default is to use a PersistentVolumeClaim mounted at /vault/data
+        # and store data there. This is only used when using a Replica count of 1, and
+        # using a stateful set. This should be HCL.
+
+        # Note: Configuration files are stored in ConfigMaps so sensitive data
+        # such as passwords should be either mounted through extraSecretEnvironmentVars
+        # or through a Kube secret.  For more information see:
+        # https://www.vaultproject.io/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
+        config: |
+          ui = true
+
+          listener "tcp" {
+            tls_disable = 1
+            address = "[::]:8200"
+            cluster_address = "[::]:8201"
+          }
+          storage "file" {
+            path = "/vault/data"
+          }
+    ui:
+      enabled: true
+      serviceType: ClusterIP

--- a/cluster/apps/vault/kustomization.yaml
+++ b/cluster/apps/vault/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml

--- a/terraform/cloudflare/services.auto.tfvars
+++ b/terraform/cloudflare/services.auto.tfvars
@@ -8,5 +8,6 @@ SERVICE_LIST = [
     "traefik",
     "grafana",
     "prometheus",
-    "kube-dashboard"
+    "kube-dashboard",
+    "vault"
 ]


### PR DESCRIPTION
1. Add standalone Vault service to Kubernetes cluster (namespace: apps).

2. Create Cloudflare DNS and Zero Trust resources for Vault.

Vault will be publicly accessible at vault.DOMAIN_NAME